### PR TITLE
feature: Support paths with `.`s in them.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+node_modules/
+
 lib-cov
 *.seed
 *.log

--- a/index.js
+++ b/index.js
@@ -5,6 +5,8 @@
 var async = require('async');
 var moment = require('moment');
 var clone = require('clone');
+// uuid must be shared among all module instances, so hard-code it:
+var uuid = 'ee0fedeb-e9b3-4690-8134-812f6d5ead28';
 
 /* PLUGIN */
 
@@ -58,14 +60,14 @@ var lockdown = function(schema, options) {
     }
 
     if (lockdownSetting === true) {
-      lockedFields[fieldName] = {
+      lockedFields[fieldName.replace('.', uuid)] = {
         saves: 0,
         max: 1,
         reset: resetOptions,
         errorMessage: errorMessage
       };
     } else if (typeof lockdownSetting === 'number') {
-      lockedFields[fieldName] = {
+      lockedFields[fieldName.replace('.', uuid)] = {
         saves: 0,
         max: lockdownSetting,
         reset: resetOptions,
@@ -91,6 +93,7 @@ var lockdown = function(schema, options) {
     console.log(self.lockdown)
 
     async.forEachOf(self.lockdown, function(value, fieldName, lockedFieldsCallback) {
+      fieldName = fieldName.replace(uuid, '.');
 
       // check for a reset
       if (!value.lastModified) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,2113 @@
+{
+  "name": "mongoose-lockdown",
+  "version": "0.1.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "async": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
+      "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
+    },
+    "clone": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+      "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk="
+    },
+    "grunt": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
+      "integrity": "sha1-VpN81RlDJK3/bSB2MYMqnWuk5/A=",
+      "dev": true,
+      "requires": {
+        "async": "0.1.22",
+        "coffee-script": "1.3.3",
+        "colors": "0.6.2",
+        "dateformat": "1.0.2-1.2.3",
+        "eventemitter2": "0.4.14",
+        "exit": "0.1.2",
+        "findup-sync": "0.1.3",
+        "getobject": "0.1.0",
+        "glob": "3.1.21",
+        "grunt-legacy-log": "0.1.2",
+        "grunt-legacy-util": "0.2.0",
+        "hooker": "0.2.3",
+        "iconv-lite": "0.2.11",
+        "js-yaml": "2.0.5",
+        "lodash": "0.9.2",
+        "minimatch": "0.2.14",
+        "nopt": "1.0.10",
+        "rimraf": "2.2.8",
+        "underscore.string": "2.2.1",
+        "which": "1.0.9"
+      },
+      "dependencies": {
+        "async": {
+          "version": "0.1.22",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz",
+          "integrity": "sha1-D8GqoIig4+8Ovi2IMbqw3PiEUGE=",
+          "dev": true
+        },
+        "coffee-script": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz",
+          "integrity": "sha1-FQ1rTLUiiUNp7+1qIQHCC8f0pPQ=",
+          "dev": true
+        },
+        "colors": {
+          "version": "0.6.2",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+          "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
+          "dev": true
+        },
+        "dateformat": {
+          "version": "1.0.2-1.2.3",
+          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz",
+          "integrity": "sha1-sCIMAt6YYXQztyhRz0fePfLNvuk=",
+          "dev": true
+        },
+        "eventemitter2": {
+          "version": "0.4.14",
+          "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
+          "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas=",
+          "dev": true
+        },
+        "exit": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+          "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+          "dev": true
+        },
+        "findup-sync": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
+          "integrity": "sha1-fz56l7gjksZTvwZYm9hRkOk8NoM=",
+          "dev": true,
+          "requires": {
+            "glob": "3.2.11",
+            "lodash": "2.4.2"
+          },
+          "dependencies": {
+            "glob": {
+              "version": "3.2.11",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+              "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+              "dev": true,
+              "requires": {
+                "inherits": "2.0.1",
+                "minimatch": "0.3.0"
+              },
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+                  "dev": true
+                },
+                "minimatch": {
+                  "version": "0.3.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                  "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
+                  "dev": true,
+                  "requires": {
+                    "lru-cache": "2.6.4",
+                    "sigmund": "1.0.1"
+                  },
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.6.4",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz",
+                      "integrity": "sha1-JnUZDM0bBwHsL2UqTQ09QA12wN0=",
+                      "dev": true
+                    },
+                    "sigmund": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "lodash": {
+              "version": "2.4.2",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+              "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
+              "dev": true
+            }
+          }
+        },
+        "getobject": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz",
+          "integrity": "sha1-BHpEl4n6Fg0Bj1SG7ZEyC27HiFw=",
+          "dev": true
+        },
+        "glob": {
+          "version": "3.1.21",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+          "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "1.2.3",
+            "inherits": "1.0.0",
+            "minimatch": "0.2.14"
+          },
+          "dependencies": {
+            "graceful-fs": {
+              "version": "1.2.3",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
+              "integrity": "sha1-FaSAaldUfLLS2/J/QuiajDRRs2Q=",
+              "dev": true
+            },
+            "inherits": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz",
+              "integrity": "sha1-OOGXUoW/H3upyE2hArsSdxMirEg=",
+              "dev": true
+            }
+          }
+        },
+        "grunt-legacy-log": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.2.tgz",
+          "integrity": "sha1-Fe4Dth4mLhs28Tdi2WeSPNHOUV4=",
+          "dev": true,
+          "requires": {
+            "colors": "0.6.2",
+            "grunt-legacy-log-utils": "0.1.1",
+            "hooker": "0.2.3",
+            "lodash": "2.4.2",
+            "underscore.string": "2.3.3"
+          },
+          "dependencies": {
+            "grunt-legacy-log-utils": {
+              "version": "0.1.1",
+              "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-0.1.1.tgz",
+              "integrity": "sha1-wHBrndkGThFvNvI/5OawSGcsD34=",
+              "dev": true,
+              "requires": {
+                "colors": "0.6.2",
+                "lodash": "2.4.2",
+                "underscore.string": "2.3.3"
+              }
+            },
+            "lodash": {
+              "version": "2.4.2",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+              "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
+              "dev": true
+            },
+            "underscore.string": {
+              "version": "2.3.3",
+              "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+              "integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0=",
+              "dev": true
+            }
+          }
+        },
+        "grunt-legacy-util": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz",
+          "integrity": "sha1-kzJIhNv343qf98Am3/RR2UqeVUs=",
+          "dev": true,
+          "requires": {
+            "async": "0.1.22",
+            "exit": "0.1.2",
+            "getobject": "0.1.0",
+            "hooker": "0.2.3",
+            "lodash": "0.9.2",
+            "underscore.string": "2.2.1",
+            "which": "1.0.9"
+          }
+        },
+        "hooker": {
+          "version": "0.2.3",
+          "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
+          "integrity": "sha1-uDT3I8xKJCqmWWNFnfbZhMXT2Vk=",
+          "dev": true
+        },
+        "iconv-lite": {
+          "version": "0.2.11",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz",
+          "integrity": "sha1-HOYKOleGSiktEyH/RgnKS7llrcg=",
+          "dev": true
+        },
+        "js-yaml": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
+          "integrity": "sha1-olrmUJmZ6X3yeMZxnaEb0Gh3Q6g=",
+          "dev": true,
+          "requires": {
+            "argparse": "0.1.16",
+            "esprima": "1.0.4"
+          },
+          "dependencies": {
+            "argparse": {
+              "version": "0.1.16",
+              "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
+              "integrity": "sha1-z9AeD7uj1srtBJ+9dY1A9lGW9Xw=",
+              "dev": true,
+              "requires": {
+                "underscore": "1.7.0",
+                "underscore.string": "2.4.0"
+              },
+              "dependencies": {
+                "underscore": {
+                  "version": "1.7.0",
+                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+                  "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk=",
+                  "dev": true
+                },
+                "underscore.string": {
+                  "version": "2.4.0",
+                  "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
+                  "integrity": "sha1-jN2PusTi0uoefi6Al8QvRCKA+Fs=",
+                  "dev": true
+                }
+              }
+            },
+            "esprima": {
+              "version": "1.0.4",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+              "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0=",
+              "dev": true
+            }
+          }
+        },
+        "lodash": {
+          "version": "0.9.2",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz",
+          "integrity": "sha1-jzSZxSRdNG1oLlsNO0B2fgnxqSw=",
+          "dev": true
+        },
+        "minimatch": {
+          "version": "0.2.14",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+          "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "2.6.4",
+            "sigmund": "1.0.1"
+          },
+          "dependencies": {
+            "lru-cache": {
+              "version": "2.6.4",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz",
+              "integrity": "sha1-JnUZDM0bBwHsL2UqTQ09QA12wN0=",
+              "dev": true
+            },
+            "sigmund": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+              "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+              "dev": true
+            }
+          }
+        },
+        "nopt": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+          "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
+          "dev": true,
+          "requires": {
+            "abbrev": "1.0.6"
+          },
+          "dependencies": {
+            "abbrev": {
+              "version": "1.0.6",
+              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.6.tgz",
+              "integrity": "sha1-ttYyuFmz+i1vfksZVHJGG54y3DA=",
+              "dev": true
+            }
+          }
+        },
+        "rimraf": {
+          "version": "2.2.8",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+          "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
+          "dev": true
+        },
+        "underscore.string": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz",
+          "integrity": "sha1-18D6KvXVoaZ/QlPa7pgTLnM/Dxk=",
+          "dev": true
+        },
+        "which": {
+          "version": "1.0.9",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz",
+          "integrity": "sha1-RgwdoPgQED0DIam2M6+eV15kSG8=",
+          "dev": true
+        }
+      }
+    },
+    "grunt-simple-mocha": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/grunt-simple-mocha/-/grunt-simple-mocha-0.4.0.tgz",
+      "integrity": "sha1-vfTBsm2Tz5OKh1SBwXhiEfqtesA=",
+      "dev": true,
+      "requires": {
+        "mocha": "2.2.5"
+      },
+      "dependencies": {
+        "mocha": {
+          "version": "2.2.5",
+          "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.2.5.tgz",
+          "integrity": "sha1-07cqT+SeyUOTU/GsiT28Qw2ZMUA=",
+          "dev": true,
+          "requires": {
+            "commander": "2.3.0",
+            "debug": "2.0.0",
+            "diff": "1.4.0",
+            "escape-string-regexp": "1.0.2",
+            "glob": "3.2.3",
+            "growl": "1.8.1",
+            "jade": "0.26.3",
+            "mkdirp": "0.5.0",
+            "supports-color": "1.2.1"
+          },
+          "dependencies": {
+            "commander": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
+              "integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM=",
+              "dev": true
+            },
+            "debug": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.0.0.tgz",
+              "integrity": "sha1-ib2d9nMrUSVrxnBTQrugLtEhMe8=",
+              "dev": true,
+              "requires": {
+                "ms": "0.6.2"
+              },
+              "dependencies": {
+                "ms": {
+                  "version": "0.6.2",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
+                  "integrity": "sha1-2JwhJMb9wTU9Zai3e/GqxLGTcIw=",
+                  "dev": true
+                }
+              }
+            },
+            "diff": {
+              "version": "1.4.0",
+              "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
+              "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
+              "dev": true
+            },
+            "escape-string-regexp": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
+              "integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE=",
+              "dev": true
+            },
+            "glob": {
+              "version": "3.2.3",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
+              "integrity": "sha1-4xPusknHr/qlxHUoaw4RW1mDlGc=",
+              "dev": true,
+              "requires": {
+                "graceful-fs": "2.0.3",
+                "inherits": "2.0.1",
+                "minimatch": "0.2.14"
+              },
+              "dependencies": {
+                "graceful-fs": {
+                  "version": "2.0.3",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
+                  "integrity": "sha1-fNLNsiiko/Nule+mzBQt59GhNtA=",
+                  "dev": true
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+                  "dev": true
+                },
+                "minimatch": {
+                  "version": "0.2.14",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                  "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
+                  "dev": true,
+                  "requires": {
+                    "lru-cache": "2.6.4",
+                    "sigmund": "1.0.1"
+                  },
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.6.4",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz",
+                      "integrity": "sha1-JnUZDM0bBwHsL2UqTQ09QA12wN0=",
+                      "dev": true
+                    },
+                    "sigmund": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "growl": {
+              "version": "1.8.1",
+              "resolved": "https://registry.npmjs.org/growl/-/growl-1.8.1.tgz",
+              "integrity": "sha1-Sy3sjZB+k9szZiTc7AGDUC+MlCg=",
+              "dev": true
+            },
+            "jade": {
+              "version": "0.26.3",
+              "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+              "integrity": "sha1-jxDXl32NefL2/4YqgbBRPMslaGw=",
+              "dev": true,
+              "requires": {
+                "commander": "0.6.1",
+                "mkdirp": "0.3.0"
+              },
+              "dependencies": {
+                "commander": {
+                  "version": "0.6.1",
+                  "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+                  "integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY=",
+                  "dev": true
+                },
+                "mkdirp": {
+                  "version": "0.3.0",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+                  "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
+                  "dev": true
+                }
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.0",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+              "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
+              "dev": true,
+              "requires": {
+                "minimist": "0.0.8"
+              },
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                  "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+                  "dev": true
+                }
+              }
+            },
+            "supports-color": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.1.tgz",
+              "integrity": "sha1-Eu4hUHCGzZjBBY2ewPSsR2t687I=",
+              "dev": true
+            }
+          }
+        }
+      }
+    },
+    "mocha": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.2.5.tgz",
+      "integrity": "sha1-07cqT+SeyUOTU/GsiT28Qw2ZMUA=",
+      "dev": true,
+      "requires": {
+        "commander": "2.3.0",
+        "debug": "2.0.0",
+        "diff": "1.4.0",
+        "escape-string-regexp": "1.0.2",
+        "glob": "3.2.3",
+        "growl": "1.8.1",
+        "jade": "0.26.3",
+        "mkdirp": "0.5.0",
+        "supports-color": "1.2.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
+          "integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM=",
+          "dev": true
+        },
+        "debug": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.0.0.tgz",
+          "integrity": "sha1-ib2d9nMrUSVrxnBTQrugLtEhMe8=",
+          "dev": true,
+          "requires": {
+            "ms": "0.6.2"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "0.6.2",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
+              "integrity": "sha1-2JwhJMb9wTU9Zai3e/GqxLGTcIw=",
+              "dev": true
+            }
+          }
+        },
+        "diff": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
+          "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
+          "dev": true
+        },
+        "escape-string-regexp": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
+          "integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE=",
+          "dev": true
+        },
+        "glob": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
+          "integrity": "sha1-4xPusknHr/qlxHUoaw4RW1mDlGc=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "2.0.3",
+            "inherits": "2.0.1",
+            "minimatch": "0.2.14"
+          },
+          "dependencies": {
+            "graceful-fs": {
+              "version": "2.0.3",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
+              "integrity": "sha1-fNLNsiiko/Nule+mzBQt59GhNtA=",
+              "dev": true
+            },
+            "inherits": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+              "dev": true
+            },
+            "minimatch": {
+              "version": "0.2.14",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+              "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
+              "dev": true,
+              "requires": {
+                "lru-cache": "2.6.4",
+                "sigmund": "1.0.1"
+              },
+              "dependencies": {
+                "lru-cache": {
+                  "version": "2.6.4",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz",
+                  "integrity": "sha1-JnUZDM0bBwHsL2UqTQ09QA12wN0=",
+                  "dev": true
+                },
+                "sigmund": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                  "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+                  "dev": true
+                }
+              }
+            }
+          }
+        },
+        "growl": {
+          "version": "1.8.1",
+          "resolved": "https://registry.npmjs.org/growl/-/growl-1.8.1.tgz",
+          "integrity": "sha1-Sy3sjZB+k9szZiTc7AGDUC+MlCg=",
+          "dev": true
+        },
+        "jade": {
+          "version": "0.26.3",
+          "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+          "integrity": "sha1-jxDXl32NefL2/4YqgbBRPMslaGw=",
+          "dev": true,
+          "requires": {
+            "commander": "0.6.1",
+            "mkdirp": "0.3.0"
+          },
+          "dependencies": {
+            "commander": {
+              "version": "0.6.1",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+              "integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY=",
+              "dev": true
+            },
+            "mkdirp": {
+              "version": "0.3.0",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+              "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
+              "dev": true
+            }
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+          "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+              "dev": true
+            }
+          }
+        },
+        "supports-color": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.1.tgz",
+          "integrity": "sha1-Eu4hUHCGzZjBBY2ewPSsR2t687I=",
+          "dev": true
+        }
+      }
+    },
+    "moment": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.10.3.tgz",
+      "integrity": "sha1-CruZ8wf2UhgwjGk17+KcV7Ggon8="
+    },
+    "mongoose": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-4.0.4.tgz",
+      "integrity": "sha1-6ysQgZwAYxK1Bd/ReZ/c3Rf0Khw=",
+      "dev": true,
+      "requires": {
+        "async": "0.9.0",
+        "bson": "0.3.2",
+        "hooks-fixed": "1.0.1",
+        "kareem": "1.0.1",
+        "mongodb": "2.0.33",
+        "mpath": "0.1.1",
+        "mpromise": "0.5.4",
+        "mquery": "1.5.1",
+        "ms": "0.1.0",
+        "muri": "1.0.0",
+        "regexp-clone": "0.0.1",
+        "sliced": "0.0.5"
+      },
+      "dependencies": {
+        "async": {
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz",
+          "integrity": "sha1-rDYTsdqb7RtHUQu0ZRuJMeRxRsc=",
+          "dev": true
+        },
+        "bson": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/bson/-/bson-0.3.2.tgz",
+          "integrity": "sha1-VnU8Xo2G0PRXRLk6lpPk9gqLvWw=",
+          "dev": true,
+          "requires": {
+            "bson-ext": "0.1.7"
+          },
+          "dependencies": {
+            "bson-ext": {
+              "version": "0.1.7",
+              "resolved": "https://registry.npmjs.org/bson-ext/-/bson-ext-0.1.7.tgz",
+              "integrity": "sha1-rvJlf8Gc0clw2+YFKZtNqWc670Q=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "nan": "1.8.4",
+                "node-pre-gyp": "https://github.com/mongodb-js/node-pre-gyp/archive/v0.6.5-appveyor.tar.gz"
+              },
+              "dependencies": {
+                "nan": {
+                  "version": "1.8.4",
+                  "resolved": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz",
+                  "integrity": "sha1-PHa1OC6rM+RLdY0oE8qdkuk0LzQ=",
+                  "dev": true,
+                  "optional": true
+                },
+                "node-pre-gyp": {
+                  "version": "https://github.com/mongodb-js/node-pre-gyp/archive/v0.6.5-appveyor.tar.gz",
+                  "integrity": "sha1-IZ2KHzyxkaDz1s80KlDvuk+86EE=",
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "mkdirp": "0.5.1",
+                    "nopt": "3.0.2",
+                    "npmlog": "1.2.1",
+                    "rc": "1.0.3",
+                    "request": "2.56.0",
+                    "rimraf": "2.3.4",
+                    "semver": "4.3.5",
+                    "tar": "2.1.1",
+                    "tar-pack": "2.0.0"
+                  },
+                  "dependencies": {
+                    "mkdirp": {
+                      "version": "0.5.1",
+                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+                      "dev": true,
+                      "requires": {
+                        "minimist": "0.0.8"
+                      },
+                      "dependencies": {
+                        "minimist": {
+                          "version": "0.0.8",
+                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "nopt": {
+                      "version": "3.0.2",
+                      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.2.tgz",
+                      "integrity": "sha1-qCqH+djD3xQP54+yllenp3RAO14=",
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "abbrev": "1.0.6"
+                      },
+                      "dependencies": {
+                        "abbrev": {
+                          "version": "1.0.6",
+                          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.6.tgz",
+                          "integrity": "sha1-ttYyuFmz+i1vfksZVHJGG54y3DA=",
+                          "dev": true,
+                          "optional": true
+                        }
+                      }
+                    },
+                    "npmlog": {
+                      "version": "1.2.1",
+                      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-1.2.1.tgz",
+                      "integrity": "sha1-KOe+YZYJtT960d0wChDWTXFiaLY=",
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "ansi": "0.3.0",
+                        "are-we-there-yet": "1.0.4",
+                        "gauge": "1.2.0"
+                      },
+                      "dependencies": {
+                        "ansi": {
+                          "version": "0.3.0",
+                          "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz",
+                          "integrity": "sha1-dLLx8YfIVTx/lQFby3YAn7Q9OOA=",
+                          "dev": true
+                        },
+                        "are-we-there-yet": {
+                          "version": "1.0.4",
+                          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.4.tgz",
+                          "integrity": "sha1-Un/jife8upCAYQa5kkTqoH6Ib4U=",
+                          "dev": true,
+                          "optional": true,
+                          "requires": {
+                            "delegates": "0.1.0",
+                            "readable-stream": "1.1.13"
+                          },
+                          "dependencies": {
+                            "delegates": {
+                              "version": "0.1.0",
+                              "resolved": "https://registry.npmjs.org/delegates/-/delegates-0.1.0.tgz",
+                              "integrity": "sha1-tLV74RoWU1F6BLJ/CUm9wyff45A=",
+                              "dev": true,
+                              "optional": true
+                            },
+                            "readable-stream": {
+                              "version": "1.1.13",
+                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                              "integrity": "sha1-9u73ZPUUyJ4rniMUanW6EGdW0j4=",
+                              "dev": true,
+                              "optional": true,
+                              "requires": {
+                                "core-util-is": "1.0.1",
+                                "inherits": "2.0.1",
+                                "isarray": "0.0.1",
+                                "string_decoder": "0.10.31"
+                              },
+                              "dependencies": {
+                                "core-util-is": {
+                                  "version": "1.0.1",
+                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                                  "integrity": "sha1-awcIWu+aPMrG7lO/nT3wwVIaVTg=",
+                                  "dev": true,
+                                  "optional": true
+                                },
+                                "inherits": {
+                                  "version": "2.0.1",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                                  "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+                                  "dev": true,
+                                  "optional": true
+                                },
+                                "isarray": {
+                                  "version": "0.0.1",
+                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                                  "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                                  "dev": true,
+                                  "optional": true
+                                },
+                                "string_decoder": {
+                                  "version": "0.10.31",
+                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                                  "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                                  "dev": true,
+                                  "optional": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "gauge": {
+                          "version": "1.2.0",
+                          "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.0.tgz",
+                          "integrity": "sha1-MJSrEoVjP3mYFDiPyPLeZ7TAEsU=",
+                          "dev": true,
+                          "optional": true,
+                          "requires": {
+                            "ansi": "0.3.0",
+                            "has-unicode": "1.0.0",
+                            "lodash.pad": "3.1.0",
+                            "lodash.padleft": "3.1.1",
+                            "lodash.padright": "3.1.1"
+                          },
+                          "dependencies": {
+                            "has-unicode": {
+                              "version": "1.0.0",
+                              "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-1.0.0.tgz",
+                              "integrity": "sha1-usXETgZML/w7j8vYxxr+CPmvyMw=",
+                              "dev": true,
+                              "optional": true
+                            },
+                            "lodash.pad": {
+                              "version": "3.1.0",
+                              "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-3.1.0.tgz",
+                              "integrity": "sha1-nxix83SaleGXtf8q51LqmFGtqWU=",
+                              "dev": true,
+                              "optional": true,
+                              "requires": {
+                                "lodash._basetostring": "3.0.0",
+                                "lodash._createpadding": "3.6.0"
+                              },
+                              "dependencies": {
+                                "lodash._basetostring": {
+                                  "version": "3.0.0",
+                                  "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.0.tgz",
+                                  "integrity": "sha1-damkqqorKodhER/1Qx59g8Ha8OI=",
+                                  "dev": true
+                                },
+                                "lodash._createpadding": {
+                                  "version": "3.6.0",
+                                  "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.0.tgz",
+                                  "integrity": "sha1-xGaFDdGgXmv+xU/Qzw2yi2gzLV4=",
+                                  "dev": true,
+                                  "optional": true,
+                                  "requires": {
+                                    "lodash.repeat": "3.0.0"
+                                  },
+                                  "dependencies": {
+                                    "lodash.repeat": {
+                                      "version": "3.0.0",
+                                      "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.0.tgz",
+                                      "integrity": "sha1-w0D0E2yZ3FsuOXs/1Qz/vRcqlLA=",
+                                      "dev": true,
+                                      "optional": true,
+                                      "requires": {
+                                        "lodash._basetostring": "3.0.0"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "lodash.padleft": {
+                              "version": "3.1.1",
+                              "resolved": "https://registry.npmjs.org/lodash.padleft/-/lodash.padleft-3.1.1.tgz",
+                              "integrity": "sha1-FQFR8eAkXtuhXVCvLXHx1c/0ZTA=",
+                              "dev": true,
+                              "optional": true,
+                              "requires": {
+                                "lodash._basetostring": "3.0.0",
+                                "lodash._createpadding": "3.6.0"
+                              },
+                              "dependencies": {
+                                "lodash._basetostring": {
+                                  "version": "3.0.0",
+                                  "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.0.tgz",
+                                  "integrity": "sha1-damkqqorKodhER/1Qx59g8Ha8OI=",
+                                  "dev": true
+                                },
+                                "lodash._createpadding": {
+                                  "version": "3.6.0",
+                                  "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.0.tgz",
+                                  "integrity": "sha1-xGaFDdGgXmv+xU/Qzw2yi2gzLV4=",
+                                  "dev": true,
+                                  "optional": true,
+                                  "requires": {
+                                    "lodash.repeat": "3.0.0"
+                                  },
+                                  "dependencies": {
+                                    "lodash.repeat": {
+                                      "version": "3.0.0",
+                                      "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.0.tgz",
+                                      "integrity": "sha1-w0D0E2yZ3FsuOXs/1Qz/vRcqlLA=",
+                                      "dev": true,
+                                      "optional": true,
+                                      "requires": {
+                                        "lodash._basetostring": "3.0.0"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "lodash.padright": {
+                              "version": "3.1.1",
+                              "resolved": "https://registry.npmjs.org/lodash.padright/-/lodash.padright-3.1.1.tgz",
+                              "integrity": "sha1-efd3C6qjlzjAQK61Rl6NiPKqzsA=",
+                              "dev": true,
+                              "optional": true,
+                              "requires": {
+                                "lodash._basetostring": "3.0.0",
+                                "lodash._createpadding": "3.6.0"
+                              },
+                              "dependencies": {
+                                "lodash._basetostring": {
+                                  "version": "3.0.0",
+                                  "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.0.tgz",
+                                  "integrity": "sha1-damkqqorKodhER/1Qx59g8Ha8OI=",
+                                  "dev": true
+                                },
+                                "lodash._createpadding": {
+                                  "version": "3.6.0",
+                                  "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.0.tgz",
+                                  "integrity": "sha1-xGaFDdGgXmv+xU/Qzw2yi2gzLV4=",
+                                  "dev": true,
+                                  "optional": true,
+                                  "requires": {
+                                    "lodash.repeat": "3.0.0"
+                                  },
+                                  "dependencies": {
+                                    "lodash.repeat": {
+                                      "version": "3.0.0",
+                                      "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.0.tgz",
+                                      "integrity": "sha1-w0D0E2yZ3FsuOXs/1Qz/vRcqlLA=",
+                                      "dev": true,
+                                      "optional": true,
+                                      "requires": {
+                                        "lodash._basetostring": "3.0.0"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "rc": {
+                      "version": "1.0.3",
+                      "resolved": "https://registry.npmjs.org/rc/-/rc-1.0.3.tgz",
+                      "integrity": "sha1-Ub8o0h8TqTJFKKljNGAWGtmjn3c=",
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "deep-extend": "0.2.11",
+                        "ini": "1.3.3",
+                        "minimist": "0.0.10",
+                        "strip-json-comments": "0.1.3"
+                      },
+                      "dependencies": {
+                        "deep-extend": {
+                          "version": "0.2.11",
+                          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz",
+                          "integrity": "sha1-eha6aXKRMjQFBhcElLyD9wdv4I8=",
+                          "dev": true,
+                          "optional": true
+                        },
+                        "ini": {
+                          "version": "1.3.3",
+                          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.3.tgz",
+                          "integrity": "sha1-wH40rvHeBq/yHUE7RY5SshUzoR4=",
+                          "dev": true,
+                          "optional": true
+                        },
+                        "minimist": {
+                          "version": "0.0.10",
+                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+                          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+                          "dev": true,
+                          "optional": true
+                        },
+                        "strip-json-comments": {
+                          "version": "0.1.3",
+                          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz",
+                          "integrity": "sha1-Fkxk43Coo8wAyeAbU55WmCPw7lQ=",
+                          "dev": true,
+                          "optional": true
+                        }
+                      }
+                    },
+                    "request": {
+                      "version": "2.56.0",
+                      "resolved": "https://registry.npmjs.org/request/-/request-2.56.0.tgz",
+                      "integrity": "sha1-Iaa9nP1q/zOndJlx/6wp6DP6KP4=",
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "aws-sign2": "0.5.0",
+                        "bl": "0.9.4",
+                        "caseless": "0.10.0",
+                        "combined-stream": "1.0.3",
+                        "forever-agent": "0.6.1",
+                        "form-data": "0.2.0",
+                        "har-validator": "1.7.1",
+                        "hawk": "2.3.1",
+                        "http-signature": "0.11.0",
+                        "isstream": "0.1.2",
+                        "json-stringify-safe": "5.0.1",
+                        "mime-types": "2.0.12",
+                        "node-uuid": "1.4.3",
+                        "oauth-sign": "0.8.0",
+                        "qs": "3.1.0",
+                        "stringstream": "0.0.4",
+                        "tough-cookie": "1.2.0",
+                        "tunnel-agent": "0.4.0"
+                      },
+                      "dependencies": {
+                        "aws-sign2": {
+                          "version": "0.5.0",
+                          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
+                          "integrity": "sha1-xXED96F/wDfwLXwuZLYC6iI/fWM=",
+                          "dev": true,
+                          "optional": true
+                        },
+                        "bl": {
+                          "version": "0.9.4",
+                          "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
+                          "integrity": "sha1-RwLd9y++Ds2CeHwAwROuoZNa0Oc=",
+                          "dev": true,
+                          "optional": true,
+                          "requires": {
+                            "readable-stream": "1.0.33"
+                          },
+                          "dependencies": {
+                            "readable-stream": {
+                              "version": "1.0.33",
+                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                              "integrity": "sha1-OjYN1mwbHX/UcFOJhg7aHQ9hEmw=",
+                              "dev": true,
+                              "optional": true,
+                              "requires": {
+                                "core-util-is": "1.0.1",
+                                "inherits": "2.0.1",
+                                "isarray": "0.0.1",
+                                "string_decoder": "0.10.31"
+                              },
+                              "dependencies": {
+                                "core-util-is": {
+                                  "version": "1.0.1",
+                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                                  "integrity": "sha1-awcIWu+aPMrG7lO/nT3wwVIaVTg=",
+                                  "dev": true,
+                                  "optional": true
+                                },
+                                "inherits": {
+                                  "version": "2.0.1",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                                  "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+                                  "dev": true,
+                                  "optional": true
+                                },
+                                "isarray": {
+                                  "version": "0.0.1",
+                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                                  "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                                  "dev": true,
+                                  "optional": true
+                                },
+                                "string_decoder": {
+                                  "version": "0.10.31",
+                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                                  "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                                  "dev": true,
+                                  "optional": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "caseless": {
+                          "version": "0.10.0",
+                          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.10.0.tgz",
+                          "integrity": "sha1-7WsnGa3NH9GPWNwIHA8aW0OWOQk=",
+                          "dev": true,
+                          "optional": true
+                        },
+                        "combined-stream": {
+                          "version": "1.0.3",
+                          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.3.tgz",
+                          "integrity": "sha1-wiTMNdPLmOJd6tUyRyoY6Pdd9as=",
+                          "dev": true,
+                          "optional": true,
+                          "requires": {
+                            "delayed-stream": "1.0.0"
+                          },
+                          "dependencies": {
+                            "delayed-stream": {
+                              "version": "1.0.0",
+                              "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+                              "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+                              "dev": true,
+                              "optional": true
+                            }
+                          }
+                        },
+                        "forever-agent": {
+                          "version": "0.6.1",
+                          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+                          "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+                          "dev": true,
+                          "optional": true
+                        },
+                        "form-data": {
+                          "version": "0.2.0",
+                          "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+                          "integrity": "sha1-Jvi8JtpkQOKZy9z7aQNcT3em5GY=",
+                          "dev": true,
+                          "optional": true,
+                          "requires": {
+                            "async": "0.9.0",
+                            "combined-stream": "0.0.7",
+                            "mime-types": "2.0.12"
+                          },
+                          "dependencies": {
+                            "combined-stream": {
+                              "version": "0.0.7",
+                              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                              "integrity": "sha1-ATfmV7qlp1QcV6w3rF/AfXO03B8=",
+                              "dev": true,
+                              "optional": true,
+                              "requires": {
+                                "delayed-stream": "0.0.5"
+                              },
+                              "dependencies": {
+                                "delayed-stream": {
+                                  "version": "0.0.5",
+                                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
+                                  "integrity": "sha1-1LH0OpPoKW3+AmlPRoC8N6MTxz8=",
+                                  "dev": true,
+                                  "optional": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "har-validator": {
+                          "version": "1.7.1",
+                          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.7.1.tgz",
+                          "integrity": "sha1-jsiVL4KH0htFG6PjbyftjZl9ipU=",
+                          "dev": true,
+                          "optional": true,
+                          "requires": {
+                            "bluebird": "2.9.26",
+                            "chalk": "1.0.0",
+                            "commander": "2.8.1",
+                            "is-my-json-valid": "2.12.0"
+                          },
+                          "dependencies": {
+                            "bluebird": {
+                              "version": "2.9.26",
+                              "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.26.tgz",
+                              "integrity": "sha1-Nidy6k0J9VakufO2TC/RNuh+OlU=",
+                              "dev": true,
+                              "optional": true
+                            },
+                            "chalk": {
+                              "version": "1.0.0",
+                              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
+                              "integrity": "sha1-s89O0P9Tl8mcdbj2edsvUoMfltw=",
+                              "dev": true,
+                              "optional": true,
+                              "requires": {
+                                "ansi-styles": "2.0.1",
+                                "escape-string-regexp": "1.0.3",
+                                "has-ansi": "1.0.3",
+                                "strip-ansi": "2.0.1",
+                                "supports-color": "1.3.1"
+                              },
+                              "dependencies": {
+                                "ansi-styles": {
+                                  "version": "2.0.1",
+                                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz",
+                                  "integrity": "sha1-sDP1f5Pi0oreuLwRE4+hPaD9IKM=",
+                                  "dev": true,
+                                  "optional": true
+                                },
+                                "escape-string-regexp": {
+                                  "version": "1.0.3",
+                                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+                                  "integrity": "sha1-ni2LJbwlVcMzZyN1DgPwmcJzW7U=",
+                                  "dev": true,
+                                  "optional": true
+                                },
+                                "has-ansi": {
+                                  "version": "1.0.3",
+                                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
+                                  "integrity": "sha1-wLWxYV2eOCsP9nFp2We0JeSMpTg=",
+                                  "dev": true,
+                                  "optional": true,
+                                  "requires": {
+                                    "ansi-regex": "1.1.1",
+                                    "get-stdin": "4.0.1"
+                                  },
+                                  "dependencies": {
+                                    "ansi-regex": {
+                                      "version": "1.1.1",
+                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
+                                      "integrity": "sha1-QchHGUZGN15qGl0Qw8oFTvn8mA0=",
+                                      "dev": true,
+                                      "optional": true
+                                    },
+                                    "get-stdin": {
+                                      "version": "4.0.1",
+                                      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+                                      "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+                                      "dev": true,
+                                      "optional": true
+                                    }
+                                  }
+                                },
+                                "strip-ansi": {
+                                  "version": "2.0.1",
+                                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                                  "integrity": "sha1-32LBqpTtLxFOHQ8h/R1QSCt5pg4=",
+                                  "dev": true,
+                                  "optional": true,
+                                  "requires": {
+                                    "ansi-regex": "1.1.1"
+                                  },
+                                  "dependencies": {
+                                    "ansi-regex": {
+                                      "version": "1.1.1",
+                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
+                                      "integrity": "sha1-QchHGUZGN15qGl0Qw8oFTvn8mA0=",
+                                      "dev": true,
+                                      "optional": true
+                                    }
+                                  }
+                                },
+                                "supports-color": {
+                                  "version": "1.3.1",
+                                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz",
+                                  "integrity": "sha1-FXWN8J2P87SswwdTn6vicJXhBC0=",
+                                  "dev": true,
+                                  "optional": true
+                                }
+                              }
+                            },
+                            "commander": {
+                              "version": "2.8.1",
+                              "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+                              "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
+                              "dev": true,
+                              "optional": true,
+                              "requires": {
+                                "graceful-readlink": "1.0.1"
+                              },
+                              "dependencies": {
+                                "graceful-readlink": {
+                                  "version": "1.0.1",
+                                  "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+                                  "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+                                  "dev": true,
+                                  "optional": true
+                                }
+                              }
+                            },
+                            "is-my-json-valid": {
+                              "version": "2.12.0",
+                              "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.0.tgz",
+                              "integrity": "sha1-j6bECLJr6VtFoj6PjEtGSlOHTSs=",
+                              "dev": true,
+                              "optional": true,
+                              "requires": {
+                                "generate-function": "2.0.0",
+                                "generate-object-property": "1.2.0",
+                                "jsonpointer": "1.1.0",
+                                "xtend": "4.0.0"
+                              },
+                              "dependencies": {
+                                "generate-function": {
+                                  "version": "2.0.0",
+                                  "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+                                  "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+                                  "dev": true,
+                                  "optional": true
+                                },
+                                "generate-object-property": {
+                                  "version": "1.2.0",
+                                  "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                                  "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+                                  "dev": true,
+                                  "optional": true,
+                                  "requires": {
+                                    "is-property": "1.0.2"
+                                  },
+                                  "dependencies": {
+                                    "is-property": {
+                                      "version": "1.0.2",
+                                      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+                                      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+                                      "dev": true,
+                                      "optional": true
+                                    }
+                                  }
+                                },
+                                "jsonpointer": {
+                                  "version": "1.1.0",
+                                  "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-1.1.0.tgz",
+                                  "integrity": "sha1-w8cu+u07lxVBY9wB3TSeHP4PgPw=",
+                                  "dev": true,
+                                  "optional": true
+                                },
+                                "xtend": {
+                                  "version": "4.0.0",
+                                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
+                                  "integrity": "sha1-i8Nv+Hrtvnzp6vC8o2sjVKdDhA8=",
+                                  "dev": true,
+                                  "optional": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "hawk": {
+                          "version": "2.3.1",
+                          "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
+                          "integrity": "sha1-HnMc45RH+h0PbXB/e87r7A/R7B8=",
+                          "dev": true,
+                          "optional": true,
+                          "requires": {
+                            "boom": "2.7.2",
+                            "cryptiles": "2.0.4",
+                            "hoek": "2.14.0",
+                            "sntp": "1.0.9"
+                          },
+                          "dependencies": {
+                            "boom": {
+                              "version": "2.7.2",
+                              "resolved": "https://registry.npmjs.org/boom/-/boom-2.7.2.tgz",
+                              "integrity": "sha1-2tYo2Jf3/S4yzIIZfxMweXHPg1Q=",
+                              "dev": true,
+                              "requires": {
+                                "hoek": "2.14.0"
+                              }
+                            },
+                            "cryptiles": {
+                              "version": "2.0.4",
+                              "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz",
+                              "integrity": "sha1-CeoXdbnhx95+YKmdQqtvCM4aEoU=",
+                              "dev": true,
+                              "optional": true,
+                              "requires": {
+                                "boom": "2.7.2"
+                              }
+                            },
+                            "hoek": {
+                              "version": "2.14.0",
+                              "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz",
+                              "integrity": "sha1-gSEWkfUqWoNa5J7b8eickANHaqQ=",
+                              "dev": true
+                            },
+                            "sntp": {
+                              "version": "1.0.9",
+                              "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+                              "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+                              "dev": true,
+                              "optional": true,
+                              "requires": {
+                                "hoek": "2.14.0"
+                              }
+                            }
+                          }
+                        },
+                        "http-signature": {
+                          "version": "0.11.0",
+                          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
+                          "integrity": "sha1-F5bPZ6ABrVzWhJ3KCZFIXwkIn+Y=",
+                          "dev": true,
+                          "optional": true,
+                          "requires": {
+                            "asn1": "0.1.11",
+                            "assert-plus": "0.1.5",
+                            "ctype": "0.5.3"
+                          },
+                          "dependencies": {
+                            "asn1": {
+                              "version": "0.1.11",
+                              "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+                              "integrity": "sha1-VZvhg3bQik7E2+gId9J4GGObLfc=",
+                              "dev": true,
+                              "optional": true
+                            },
+                            "assert-plus": {
+                              "version": "0.1.5",
+                              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+                              "integrity": "sha1-7nQAlBMALYTOxyGcasgRgS5yMWA=",
+                              "dev": true,
+                              "optional": true
+                            },
+                            "ctype": {
+                              "version": "0.5.3",
+                              "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+                              "integrity": "sha1-gsGMJGH3QRTvFsE1IkrQuRRMoS8=",
+                              "dev": true,
+                              "optional": true
+                            }
+                          }
+                        },
+                        "isstream": {
+                          "version": "0.1.2",
+                          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+                          "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+                          "dev": true,
+                          "optional": true
+                        },
+                        "json-stringify-safe": {
+                          "version": "5.0.1",
+                          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+                          "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+                          "dev": true,
+                          "optional": true
+                        },
+                        "mime-types": {
+                          "version": "2.0.12",
+                          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.12.tgz",
+                          "integrity": "sha1-h66fEk6U+ORAyT0actDczs23ETU=",
+                          "dev": true,
+                          "requires": {
+                            "mime-db": "1.10.0"
+                          },
+                          "dependencies": {
+                            "mime-db": {
+                              "version": "1.10.0",
+                              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.10.0.tgz",
+                              "integrity": "sha1-5jCAY8dY69EoN4dMPR6pFwdmsDs=",
+                              "dev": true
+                            }
+                          }
+                        },
+                        "node-uuid": {
+                          "version": "1.4.3",
+                          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz",
+                          "integrity": "sha1-MZu3pW58tj8AtcDNeFHNS03fHfk=",
+                          "dev": true,
+                          "optional": true
+                        },
+                        "oauth-sign": {
+                          "version": "0.8.0",
+                          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz",
+                          "integrity": "sha1-k4/ch1dlulJxN9iuydF44k3rxVM=",
+                          "dev": true,
+                          "optional": true
+                        },
+                        "qs": {
+                          "version": "3.1.0",
+                          "resolved": "https://registry.npmjs.org/qs/-/qs-3.1.0.tgz",
+                          "integrity": "sha1-0OmudFIzoS3EP7TzBVu6RGJhFTw=",
+                          "dev": true,
+                          "optional": true
+                        },
+                        "stringstream": {
+                          "version": "0.0.4",
+                          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz",
+                          "integrity": "sha1-Dw40I/lClgtWkqwySlfdCTvEGpI=",
+                          "dev": true,
+                          "optional": true
+                        },
+                        "tough-cookie": {
+                          "version": "1.2.0",
+                          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-1.2.0.tgz",
+                          "integrity": "sha1-m36dmOdp6AtaqJnZRP5E4C6/gq0=",
+                          "dev": true,
+                          "optional": true
+                        },
+                        "tunnel-agent": {
+                          "version": "0.4.0",
+                          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz",
+                          "integrity": "sha1-sRhOMS/7z3CztMeOjCGd5+uxxVA=",
+                          "dev": true,
+                          "optional": true
+                        }
+                      }
+                    },
+                    "rimraf": {
+                      "version": "2.3.4",
+                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.3.4.tgz",
+                      "integrity": "sha1-gtm8Gy/PMeIFrHsoE4oCXQjpFZo=",
+                      "dev": true,
+                      "requires": {
+                        "glob": "4.5.3"
+                      },
+                      "dependencies": {
+                        "glob": {
+                          "version": "4.5.3",
+                          "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+                          "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
+                          "dev": true,
+                          "requires": {
+                            "inflight": "1.0.4",
+                            "inherits": "2.0.1",
+                            "minimatch": "2.0.8",
+                            "once": "1.3.2"
+                          },
+                          "dependencies": {
+                            "inflight": {
+                              "version": "1.0.4",
+                              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                              "integrity": "sha1-bLtFIevVHODsCpNr/XZX736bFyo=",
+                              "dev": true,
+                              "requires": {
+                                "once": "1.3.2",
+                                "wrappy": "1.0.1"
+                              },
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1",
+                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                                  "integrity": "sha1-HmWWmWXMvC20VIxrhKbyxa7dRzk=",
+                                  "dev": true
+                                }
+                              }
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                              "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+                              "dev": true
+                            },
+                            "minimatch": {
+                              "version": "2.0.8",
+                              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
+                              "integrity": "sha1-C8IPa/NXCmmO8N3/kCBjxsq9pr8=",
+                              "dev": true,
+                              "requires": {
+                                "brace-expansion": "1.1.0"
+                              },
+                              "dependencies": {
+                                "brace-expansion": {
+                                  "version": "1.1.0",
+                                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                                  "integrity": "sha1-ybfQPAPze8cEvhAOUitA249s/Nk=",
+                                  "dev": true,
+                                  "requires": {
+                                    "balanced-match": "0.2.0",
+                                    "concat-map": "0.0.1"
+                                  },
+                                  "dependencies": {
+                                    "balanced-match": {
+                                      "version": "0.2.0",
+                                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
+                                      "integrity": "sha1-OPZzDAOqttXtu1K9k0iF51bXFnQ=",
+                                      "dev": true
+                                    },
+                                    "concat-map": {
+                                      "version": "0.0.1",
+                                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                                      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+                                      "dev": true
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "once": {
+                              "version": "1.3.2",
+                              "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                              "integrity": "sha1-2P7sqTsDnsHc3ud0HJK9rF4oCBs=",
+                              "dev": true,
+                              "requires": {
+                                "wrappy": "1.0.1"
+                              },
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1",
+                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                                  "integrity": "sha1-HmWWmWXMvC20VIxrhKbyxa7dRzk=",
+                                  "dev": true
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "semver": {
+                      "version": "4.3.5",
+                      "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.5.tgz",
+                      "integrity": "sha1-wghlqLuOG2rJWKOQyOg1U4+gxwc=",
+                      "dev": true,
+                      "optional": true
+                    },
+                    "tar": {
+                      "version": "2.1.1",
+                      "resolved": "https://registry.npmjs.org/tar/-/tar-2.1.1.tgz",
+                      "integrity": "sha1-rAZJ4TX6RUbkMMdphRTh2i6KfMQ=",
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "block-stream": "0.0.8",
+                        "fstream": "1.0.6",
+                        "inherits": "2.0.1"
+                      },
+                      "dependencies": {
+                        "block-stream": {
+                          "version": "0.0.8",
+                          "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz",
+                          "integrity": "sha1-Boj0baK7+c/wxPaCJaDLlcvopGs=",
+                          "dev": true,
+                          "optional": true,
+                          "requires": {
+                            "inherits": "2.0.1"
+                          }
+                        },
+                        "fstream": {
+                          "version": "1.0.6",
+                          "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.6.tgz",
+                          "integrity": "sha1-gX5QMS+07ZDahlyOtezR0deu0Ow=",
+                          "dev": true,
+                          "optional": true,
+                          "requires": {
+                            "graceful-fs": "3.0.7",
+                            "inherits": "2.0.1",
+                            "mkdirp": "0.5.1",
+                            "rimraf": "2.3.4"
+                          },
+                          "dependencies": {
+                            "graceful-fs": {
+                              "version": "3.0.7",
+                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.7.tgz",
+                              "integrity": "sha1-6TW+Sz5XiS0oncO+976MAnedK1Q=",
+                              "dev": true,
+                              "optional": true
+                            }
+                          }
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "tar-pack": {
+                      "version": "2.0.0",
+                      "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-2.0.0.tgz",
+                      "integrity": "sha1-wsQBwC3TZhOGRekXs6a6olap3Ks=",
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "debug": "0.7.4",
+                        "fstream": "0.1.31",
+                        "fstream-ignore": "0.0.7",
+                        "graceful-fs": "1.2.3",
+                        "once": "1.1.1",
+                        "readable-stream": "1.0.33",
+                        "rimraf": "2.2.8",
+                        "tar": "0.1.20",
+                        "uid-number": "0.0.3"
+                      },
+                      "dependencies": {
+                        "debug": {
+                          "version": "0.7.4",
+                          "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
+                          "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk=",
+                          "dev": true,
+                          "optional": true
+                        },
+                        "fstream": {
+                          "version": "0.1.31",
+                          "resolved": "https://registry.npmjs.org/fstream/-/fstream-0.1.31.tgz",
+                          "integrity": "sha1-czfwWPu7vvqMn1YaKMqwhJICyYg=",
+                          "dev": true,
+                          "requires": {
+                            "graceful-fs": "3.0.7",
+                            "inherits": "2.0.1",
+                            "mkdirp": "0.5.1",
+                            "rimraf": "2.2.8"
+                          },
+                          "dependencies": {
+                            "graceful-fs": {
+                              "version": "3.0.7",
+                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.7.tgz",
+                              "integrity": "sha1-6TW+Sz5XiS0oncO+976MAnedK1Q=",
+                              "dev": true
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                              "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+                              "dev": true
+                            }
+                          }
+                        },
+                        "fstream-ignore": {
+                          "version": "0.0.7",
+                          "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-0.0.7.tgz",
+                          "integrity": "sha1-7qMDPww3KBOd57V6sbDW2Jw1PGM=",
+                          "dev": true,
+                          "optional": true,
+                          "requires": {
+                            "fstream": "0.1.31",
+                            "inherits": "2.0.1",
+                            "minimatch": "0.2.14"
+                          },
+                          "dependencies": {
+                            "inherits": {
+                              "version": "2.0.1",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                              "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+                              "dev": true,
+                              "optional": true
+                            },
+                            "minimatch": {
+                              "version": "0.2.14",
+                              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                              "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
+                              "dev": true,
+                              "optional": true,
+                              "requires": {
+                                "lru-cache": "2.6.4",
+                                "sigmund": "1.0.1"
+                              },
+                              "dependencies": {
+                                "lru-cache": {
+                                  "version": "2.6.4",
+                                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz",
+                                  "integrity": "sha1-JnUZDM0bBwHsL2UqTQ09QA12wN0=",
+                                  "dev": true,
+                                  "optional": true
+                                },
+                                "sigmund": {
+                                  "version": "1.0.1",
+                                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                                  "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+                                  "dev": true,
+                                  "optional": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "graceful-fs": {
+                          "version": "1.2.3",
+                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
+                          "integrity": "sha1-FaSAaldUfLLS2/J/QuiajDRRs2Q=",
+                          "dev": true,
+                          "optional": true
+                        },
+                        "once": {
+                          "version": "1.1.1",
+                          "resolved": "https://registry.npmjs.org/once/-/once-1.1.1.tgz",
+                          "integrity": "sha1-nbV0kzzLCMOnYU0VQDLAnqbzOec=",
+                          "dev": true,
+                          "optional": true
+                        },
+                        "readable-stream": {
+                          "version": "1.0.33",
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                          "integrity": "sha1-OjYN1mwbHX/UcFOJhg7aHQ9hEmw=",
+                          "dev": true,
+                          "optional": true,
+                          "requires": {
+                            "core-util-is": "1.0.1",
+                            "inherits": "2.0.1",
+                            "isarray": "0.0.1",
+                            "string_decoder": "0.10.31"
+                          },
+                          "dependencies": {
+                            "core-util-is": {
+                              "version": "1.0.1",
+                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                              "integrity": "sha1-awcIWu+aPMrG7lO/nT3wwVIaVTg=",
+                              "dev": true,
+                              "optional": true
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                              "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+                              "dev": true,
+                              "optional": true
+                            },
+                            "isarray": {
+                              "version": "0.0.1",
+                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                              "dev": true,
+                              "optional": true
+                            },
+                            "string_decoder": {
+                              "version": "0.10.31",
+                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                              "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                              "dev": true,
+                              "optional": true
+                            }
+                          }
+                        },
+                        "rimraf": {
+                          "version": "2.2.8",
+                          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+                          "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
+                          "dev": true
+                        },
+                        "tar": {
+                          "version": "0.1.20",
+                          "resolved": "https://registry.npmjs.org/tar/-/tar-0.1.20.tgz",
+                          "integrity": "sha1-QpQLrltfIsdEg2mRJvnz8nRJyxM=",
+                          "dev": true,
+                          "optional": true,
+                          "requires": {
+                            "block-stream": "0.0.8",
+                            "fstream": "0.1.31",
+                            "inherits": "2.0.1"
+                          },
+                          "dependencies": {
+                            "block-stream": {
+                              "version": "0.0.8",
+                              "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz",
+                              "integrity": "sha1-Boj0baK7+c/wxPaCJaDLlcvopGs=",
+                              "dev": true,
+                              "optional": true,
+                              "requires": {
+                                "inherits": "2.0.1"
+                              }
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                              "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+                              "dev": true
+                            }
+                          }
+                        },
+                        "uid-number": {
+                          "version": "0.0.3",
+                          "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.3.tgz",
+                          "integrity": "sha1-zvsPoTjY2AmNpxpAoNBKgyfW4cw=",
+                          "dev": true,
+                          "optional": true
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "hooks-fixed": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/hooks-fixed/-/hooks-fixed-1.0.1.tgz",
+          "integrity": "sha1-8fZpSmIxf7NsEf+wZ3CKFZR+b54=",
+          "dev": true
+        },
+        "kareem": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/kareem/-/kareem-1.0.1.tgz",
+          "integrity": "sha1-eAXSFbtTIU7Dr5aaHQsfF+PnuVw=",
+          "dev": true
+        },
+        "mongodb": {
+          "version": "2.0.33",
+          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.0.33.tgz",
+          "integrity": "sha1-D/aRjAA0I/ksp26F2hYkCANZ8xM=",
+          "dev": true,
+          "requires": {
+            "mongodb-core": "1.1.32",
+            "readable-stream": "1.0.31"
+          },
+          "dependencies": {
+            "mongodb-core": {
+              "version": "1.1.32",
+              "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-1.1.32.tgz",
+              "integrity": "sha1-+GNUnAiIGrKzgrjoeGQbPgb9dsw=",
+              "dev": true,
+              "requires": {
+                "bson": "0.3.2",
+                "kerberos": "0.0.12"
+              },
+              "dependencies": {
+                "kerberos": {
+                  "version": "0.0.12",
+                  "resolved": "https://registry.npmjs.org/kerberos/-/kerberos-0.0.12.tgz",
+                  "integrity": "sha1-fSXMq3SiMlwYaxpWdhBDpHiciXI=",
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "nan": "1.8.4"
+                  },
+                  "dependencies": {
+                    "nan": {
+                      "version": "1.8.4",
+                      "resolved": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz",
+                      "integrity": "sha1-PHa1OC6rM+RLdY0oE8qdkuk0LzQ=",
+                      "dev": true,
+                      "optional": true
+                    }
+                  }
+                }
+              }
+            },
+            "readable-stream": {
+              "version": "1.0.31",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.31.tgz",
+              "integrity": "sha1-jyUC4LyeOw2huUUgqrtOJgPsr64=",
+              "dev": true,
+              "requires": {
+                "core-util-is": "1.0.1",
+                "inherits": "2.0.1",
+                "isarray": "0.0.1",
+                "string_decoder": "0.10.31"
+              },
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                  "integrity": "sha1-awcIWu+aPMrG7lO/nT3wwVIaVTg=",
+                  "dev": true
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+                  "dev": true
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                  "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                  "dev": true
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                  "dev": true
+                }
+              }
+            }
+          }
+        },
+        "mpath": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.1.1.tgz",
+          "integrity": "sha1-I9qFK3wjLuCX9HWdKcDunNItXkY=",
+          "dev": true
+        },
+        "mpromise": {
+          "version": "0.5.4",
+          "resolved": "https://registry.npmjs.org/mpromise/-/mpromise-0.5.4.tgz",
+          "integrity": "sha1-thBhPsbeN0GflEs18Hg7Ten13HU=",
+          "dev": true
+        },
+        "mquery": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/mquery/-/mquery-1.5.1.tgz",
+          "integrity": "sha1-9gu/ih4Oxu8/8fIhI7iwP4OpFiU=",
+          "dev": true,
+          "requires": {
+            "bluebird": "2.9.9",
+            "debug": "0.7.4",
+            "regexp-clone": "0.0.1",
+            "sliced": "0.0.5"
+          },
+          "dependencies": {
+            "bluebird": {
+              "version": "2.9.9",
+              "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.9.tgz",
+              "integrity": "sha1-YaJpBNQ9f2sZ3/ftkX28kkUq1tM=",
+              "dev": true
+            },
+            "debug": {
+              "version": "0.7.4",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
+              "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk=",
+              "dev": true
+            }
+          }
+        },
+        "ms": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.1.0.tgz",
+          "integrity": "sha1-8h+sSQ2vHXZn/RgP6QdzicyUQrI=",
+          "dev": true
+        },
+        "muri": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/muri/-/muri-1.0.0.tgz",
+          "integrity": "sha1-3jv2vXHWfq5x12aJuVDS3hGGlcY=",
+          "dev": true
+        },
+        "regexp-clone": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/regexp-clone/-/regexp-clone-0.0.1.tgz",
+          "integrity": "sha1-p8LgmJH9vzj7sQ03b7cwA+aKxYk=",
+          "dev": true
+        },
+        "sliced": {
+          "version": "0.0.5",
+          "resolved": "https://registry.npmjs.org/sliced/-/sliced-0.0.5.tgz",
+          "integrity": "sha1-XtwETKTrb3gW1Qui/GPiXY/kcH8=",
+          "dev": true
+        }
+      }
+    },
+    "should": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/should/-/should-6.0.3.tgz",
+      "integrity": "sha1-2u4weGpVdmL7x3TACNfFh5Htsdk=",
+      "dev": true,
+      "requires": {
+        "should-equal": "0.3.1",
+        "should-format": "0.0.7",
+        "should-type": "0.0.4"
+      },
+      "dependencies": {
+        "should-equal": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/should-equal/-/should-equal-0.3.1.tgz",
+          "integrity": "sha1-vY6pemdI45+tR2o75v1y68LnK/A=",
+          "dev": true,
+          "requires": {
+            "should-type": "0.0.4"
+          }
+        },
+        "should-format": {
+          "version": "0.0.7",
+          "resolved": "https://registry.npmjs.org/should-format/-/should-format-0.0.7.tgz",
+          "integrity": "sha1-Hi74a9kdqcLgQSM1tWq6vZov3hI=",
+          "dev": true,
+          "requires": {
+            "should-type": "0.0.4"
+          }
+        },
+        "should-type": {
+          "version": "0.0.4",
+          "resolved": "https://registry.npmjs.org/should-type/-/should-type-0.0.4.tgz",
+          "integrity": "sha1-ATKgVBemEmhmQmrPEW8e1WI6XNA=",
+          "dev": true
+        }
+      }
+    },
+    "uuid": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   "dependencies": {
     "async": "^1.0.0",
     "clone": "^1.0.2",
-    "moment": "^2.10.3"
+    "moment": "^2.10.3",
+    "uuid": "^3.1.0"
   },
   "devDependencies": {
     "async": "*",

--- a/tests/mongoose-lockdown.js
+++ b/tests/mongoose-lockdown.js
@@ -30,6 +30,12 @@ var UserSchema = new Schema({
       period: 'seconds'
     }
   },
+  outter: {
+    inner: {
+      type: String,
+      lockdown: true
+    }
+  },
   posts: [{
     title: {
       type: String,
@@ -119,4 +125,25 @@ describe('lockdown', function() {
     });
   });
 
+  it('should not allow a save to an inner field', function(done) {
+    var user5 = new User({
+      name: 'bombsheltersoftware',
+      username: 'thebomb',
+      email: 'colin@thebomb.com',
+      outter: {
+        inner: 'i blew up before we supported `.`s in fieldname'
+      },
+      posts: [{
+        title: 'First Post'
+      }]
+    });
+    user5.save(function(err) {
+      should.not.exist(err);
+      user5.outter.inner = 'new val';
+      user5.save(function(err) {
+        should.exist(err);
+        return done();
+      });
+    });
+  });
 });


### PR DESCRIPTION
Before, `lockedFields[fieldName]` would blow up if `fieldName` had a `.` (see new test for an example of when this could be the case).